### PR TITLE
Delete Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: node app.js


### PR DESCRIPTION
> A Procfile is not required to run a Node.js app on Heroku. If no Procfile is present in the root directory of your app during the build process, we will check for a scripts.start entry in your package.json file. If a start script entry is present, a default Procfile is generated automatically.

Source: https://devcenter.heroku.com/articles/nodejs-support
