### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Recommened reading: [Airbnb JavaScript Style Guide](https://github.com/airbnb/ja
 Obtaining API Keys
 ------------------
 
-#<img src="http://images.google.com/intl/en_ALL/images/srpr/logo6w.png" width="100">
+# <img src="http://images.google.com/intl/en_ALL/images/srpr/logo6w.png" width="100">
 - Visit [Google Cloud Console](https://cloud.google.com/console/project)
 - Click **CREATE PROJECT** button
 - Enter *Project Name*, then click **CREATE**
@@ -286,7 +286,7 @@ Obtaining API Keys
 
 :exclamation: **Note**: When you ready to deploy to production don't forget to add your new url to **Authorized Javascript origins** and **Authorized redirect URI**, e.g. `http://my-awesome-app.herokuapp.com` and `http://my-awesome-app.herokuapp.com/auth/google/callback` respectively. The same goes for other providers.
 
-#<img src="http://www.doit.ba/img/facebook.jpg" width="100">
+# <img src="http://www.doit.ba/img/facebook.jpg" width="100">
 - Visit [Facebook Developers](https://developers.facebook.com/)
 - Click **Apps > Create a New App** in the navigation bar
 - Enter *Display Name*, then choose a category, then click **Create app**
@@ -296,7 +296,7 @@ Obtaining API Keys
 - Select **Website**
 - Enter `http://localhost:3000` for *Site URL*
 
-#<img src="https://github.global.ssl.fastly.net/images/modules/logos_page/GitHub-Logo.png" width="100">
+# <img src="https://github.global.ssl.fastly.net/images/modules/logos_page/GitHub-Logo.png" width="100">
 - Go to [Account Settings](https://github.com/settings/profile)
 - Select **Applications** from the sidebar
 - Then inside **Developer applications** click on **Register new application**
@@ -305,7 +305,7 @@ Obtaining API Keys
 - Click **Register application**
 - Now copy and paste *Client ID* and *Client Secret* keys into `config/config.js`
 
-#<img src="https://g.twimg.com/Twitter_logo_blue.png" width="50">
+# <img src="https://g.twimg.com/Twitter_logo_blue.png" width="50">
 - Sign in at [https://dev.twitter.com](https://dev.twitter.com/)
 - From the profile picture dropdown menu select **My Applications**
 - Click **Create a new application**
@@ -317,7 +317,7 @@ Obtaining API Keys
 - Click **Update this Twitter's applications settings**
 - Copy and paste *Consumer Key* and *Consumer Secret* keys into `config/config.js`
 
-#<img src="https://www.paypalobjects.com/webstatic/developer/logo_paypal-developer_beta.png" width="200">
+# <img src="https://www.paypalobjects.com/webstatic/developer/logo_paypal-developer_beta.png" width="200">
 - Visit [PayPal Developer](https://developer.paypal.com/)
 - Log in using your existing PayPal account
 - Click **Applications > Create App** in the navigation bar
@@ -327,7 +327,7 @@ Obtaining API Keys
 - Make a note of your Sandbox accounts (test user accounts) for testing purposes.  
 - Change **host** to api.paypal.com if you want to test against production and use the live credentials
 
-#<img src="https://www.dropboxatwork.com/wp-content/uploads/2013/02/foursquare-logo.png" width="100">
+# <img src="https://www.dropboxatwork.com/wp-content/uploads/2013/02/foursquare-logo.png" width="100">
 - Go to [foursquare for Developers](https://developer.foursquare.com/)
 - Click on **My Apps** in the top menu
 - Click the **Create A New App** button
@@ -336,7 +336,7 @@ Obtaining API Keys
 - Click **Save Changes**
 - Copy and paste *Client ID* and *Client Secret* keys into `config/config.js`
 
-#<img src="http://www.athgo.org/ablog/wp-content/uploads/2013/02/tumblr_logo.png" width="100">
+# <img src="http://www.athgo.org/ablog/wp-content/uploads/2013/02/tumblr_logo.png" width="100">
 - Go to http://www.tumblr.com/oauth/apps
 - Once signed in, click **+Register application**
 - Fill in all the details
@@ -347,7 +347,7 @@ Obtaining API Keys
 FAQ
 ---
 
-###How do I create a new page?
+### How do I create a new page?
 
 You need to create just two files and edit one:
 

--- a/public/lib/jquery.complexify.js/README.md
+++ b/public/lib/jquery.complexify.js/README.md
@@ -10,11 +10,11 @@ Complexify aims to provide a good measure of password complexity for websites to
 
 _Note:_ I use the term 'casually' because this is only client-side validation and anyone could turn it off. I recommend implementing a minimum length check server-side as well. In the future I may code up this algorithm for use server-side.
 
-###Complexity Rating
+### Complexity Rating
 
 Complexify's default settings will enforce a minimum level of complexity that would mean brute-forcing should take ~600 years on a commodity desktop machine. The 'perfect' password used to scale the complexity percentage would take 3x10^33 years. These are equivalent to a 12 character password with uppercase, lowercase and numbers included, and a 25 character password with uppercase, lowercase, numbers and a wide range of punctuation.
 
-###Unicode
+### Unicode
 
 Complexify supports Unicode and will add appropriate complexity for the size of character set included in a password. 
 
@@ -22,7 +22,7 @@ For example, as there are 96 Hiragana characters defined in the Unicode specific
 
 The rationale behind this is that in an attacker were wanting to include Japanese passwords in his attack, he/she may choose to include the Hiragana set in his/her attack, but not the Katakana set. Complexify divides Unicode into 94 appropriately grouped sets.
 
-###Using a Password Ban List
+### Using a Password Ban List
 
 If you wish to provide a list of passwords that will always return 0% complexity, this is now possibly by passing a `bannedPasswords` array into the options of Complexify, or by setting the global `COMPLEXIFY_BANLIST` variable to an array of passwords. Including `jquery.complexify.banlist.js` in your page is a quick and easy way to do the latter option.
 
@@ -33,7 +33,7 @@ The ban list has 2 modes: 'loose' and 'strict', with 'strict' being the default.
 
 By default, the banned passwords list is empty and therefore this has no effect.
 
-###Version History
+### Version History
 
 **0.3** - Banned password list support, better event binding.
 
@@ -43,7 +43,7 @@ By default, the banned passwords list is empty and therefore this has no effect.
 **0.1** - Basic implementation
 
 
-###Alternative Implementations
+### Alternative Implementations
 
 Several people have kindly open-sourced their implementations of this algorithm in other languages:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
